### PR TITLE
Don't allow copy of services

### DIFF
--- a/src/BatteryBleService.h
+++ b/src/BatteryBleService.h
@@ -11,6 +11,7 @@ class BatteryBleService final : public IBleServiceProvider {
 public:
   explicit BatteryBleService(IBleServiceLibrary &bleLibrary)
       : IBleServiceProvider(bleLibrary) {}
+
   bool begin() override;
 
   void setBatteryLevel(uint8_t value) const;

--- a/src/BleAdvertisement.h
+++ b/src/BleAdvertisement.h
@@ -9,9 +9,13 @@ namespace sensirion::upt::ble_server {
 
 class BleAdvertisement {
 public:
-  explicit BleAdvertisement(IBleAdvertisementLibrary &bleLibrary,
-                            const core::SampleConfig &sampleConfig)
-      : mSampleConfig(sampleConfig), mAdvertisementLibrary(bleLibrary){};
+  explicit BleAdvertisement(
+      IBleAdvertisementLibrary &bleLibrary,
+      const core::SampleConfig &sampleConfig) // NOLINT(*-pass-by-value)
+      : mSampleConfig(sampleConfig), mAdvertisementLibrary(bleLibrary) {};
+
+  // Don't allow copy of BLE advertisement
+  BleAdvertisement &operator=(const BleAdvertisement &&) = delete;
 
   void begin();
 

--- a/src/DownloadBleService.h
+++ b/src/DownloadBleService.h
@@ -27,13 +27,13 @@ class DownloadBleService final : IBleServiceProvider {
 public:
   explicit DownloadBleService(IBleServiceLibrary &bleLibrary,
                               const core::SampleConfig &sampleConfig)
-      : IBleServiceProvider(bleLibrary), mSampleConfig(sampleConfig){};
+      : IBleServiceProvider(bleLibrary), mSampleConfig(sampleConfig) {};
 
   bool begin() override;
 
   void commitSample(const Sample &sample);
   void handleDownload();
-  bool isDownloading() const;
+  [[nodiscard]] bool isDownloading() const;
   void setSampleConfig(const core::SampleConfig &sampleConfig) {
     mSampleConfig = sampleConfig;
     mSampleHistory.setSampleSize(mSampleConfig.sampleSizeBytes);
@@ -58,11 +58,12 @@ private:
   uint64_t mLatestHistoryTimeStampAtDownloadStart = 0;
 
 private:
-  DownloadHeader buildDownloadHeader() const;
+  [[nodiscard]] DownloadHeader buildDownloadHeader() const;
 
   DownloadPacket buildDownloadPacket();
 
-  uint32_t numberOfPacketsRequired(uint32_t numberOfSamples) const;
+  [[nodiscard]] uint32_t
+  numberOfPacketsRequired(uint32_t numberOfSamples) const;
 };
 
 } // namespace sensirion::upt::ble_server

--- a/src/FrcBleService.h
+++ b/src/FrcBleService.h
@@ -17,7 +17,7 @@ public:
 
   bool begin() override;
 
-  void registerFrcRequestCallback(const frc_request_callback_t callback) const;
+  void registerFrcRequestCallback(frc_request_callback_t callback) const;
 };
 
 } // namespace sensirion::upt::ble_server

--- a/src/IBleServiceProvider.h
+++ b/src/IBleServiceProvider.h
@@ -50,6 +50,9 @@ public:
 
   virtual ~IBleServiceProvider() = default;
 
+  // Don't allow copy of services
+  IBleServiceProvider &operator=(const IBleServiceProvider &&) = delete;
+
   /*
    * Create BLE services and characteristics.
    * Set initial values on characteristics.

--- a/src/SettingsBleService.h
+++ b/src/SettingsBleService.h
@@ -15,6 +15,7 @@ class SettingsBleService final : public IBleServiceProvider {
 public:
   explicit SettingsBleService(IBleServiceLibrary &bleLibrary)
       : IBleServiceProvider(bleLibrary) {}
+
   bool begin() override;
 
   /**

--- a/src/UptBleServer.h
+++ b/src/UptBleServer.h
@@ -51,6 +51,9 @@ public:
         mDownloadBleService{mBleLibrary, mSampleConfig},
         mBleAdvertisement{mBleLibrary, mSampleConfig} {};
 
+  // Don't allow copy of UptBleServer
+  UptBleServer& operator=(const UptBleServer&&) = delete;
+
   void begin();
 
   [[nodiscard]] String getDeviceIdString() const;


### PR DESCRIPTION
Upt BLE server and services should not be copied. This commit removes the copy constructor and makes the server and services non-copyable.